### PR TITLE
Fix invalid url for endstates

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -41,7 +41,9 @@ class PaymentsController < ApplicationController
       return redirect_to success_payments_path, notice: "Your registration has already been paid."
     end
 
-    if mollie_payment.nil? || mollie_payment.checkout_url.blank? || !retryable_mollie_status?(mollie_payment.status)
+    if mollie_payment.nil?
+      mollie_payment = create_mollie_payment_for(@payment)
+    elsif mollie_payment.checkout_url.blank? || !retryable_mollie_status?(mollie_payment.status)
       @payment = build_payment_for(@participant)
       created_payment = true
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -54,9 +54,9 @@ class PaymentsController < ApplicationController
       mollie_payment = create_mollie_payment_for(@payment)
     end
 
-    @payment.update!(mollie_payment_id: mollie_payment.id) if @payment.mollie_payment_id.blank?
-
     raise Mollie::Exception, "No checkout URL was returned by Mollie." if mollie_payment.checkout_url.blank?
+
+    @payment.update!(mollie_payment_id: mollie_payment.id) if @payment.mollie_payment_id.blank?
 
     redirect_to mollie_payment.checkout_url, allow_other_host: true
   rescue Mollie::Exception => e
@@ -136,7 +136,7 @@ class PaymentsController < ApplicationController
       description: payment.description,
       redirect_url: success_payments_url(payment_id: payment.id),
       webhook_url: webhook_payments_url,
-      metadata: { payment_id: payment.id, participant_id: @participant.id }
+      metadata: { payment_id: payment.id, participant_id: payment.participant_id }
     )
   end
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -31,19 +31,30 @@ class PaymentsController < ApplicationController
       end
     end
 
-    mollie_payment = if @payment.mollie_payment_id.present?
-      Mollie::Payment.get(@payment.mollie_payment_id)
-    else
-      Mollie::Payment.create(
-        amount: { value: format("%.2f", @payment.amount_eur), currency: "EUR" },
-        description: @payment.description,
-        redirect_url: success_payments_url(payment_id: @payment.id),
-        webhook_url: webhook_payments_url,
-        metadata: { payment_id: @payment.id, participant_id: @participant.id }
-      )
+    mollie_payment = @payment.mollie_payment_id.present? ? Mollie::Payment.get(@payment.mollie_payment_id) : nil
+
+    if mollie_payment&.status.present? && @payment.status != mollie_payment.status
+      @payment.update!(status: mollie_payment.status)
+    end
+
+    if mollie_payment&.status == "paid"
+      return redirect_to success_payments_path, notice: "Your registration has already been paid."
+    end
+
+    if mollie_payment.nil? || mollie_payment.checkout_url.blank? || !retryable_mollie_status?(mollie_payment.status)
+      @payment = build_payment_for(@participant)
+      created_payment = true
+
+      unless @payment.save
+        render :new, status: :unprocessable_entity and return
+      end
+
+      mollie_payment = create_mollie_payment_for(@payment)
     end
 
     @payment.update!(mollie_payment_id: mollie_payment.id) if @payment.mollie_payment_id.blank?
+
+    raise Mollie::Exception, "No checkout URL was returned by Mollie." if mollie_payment.checkout_url.blank?
 
     redirect_to mollie_payment.checkout_url, allow_other_host: true
   rescue Mollie::Exception => e
@@ -115,5 +126,19 @@ class PaymentsController < ApplicationController
       description: pricing.description,
       status: "open"
     )
+  end
+
+  def create_mollie_payment_for(payment)
+    Mollie::Payment.create(
+      amount: { value: format("%.2f", payment.amount_eur), currency: "EUR" },
+      description: payment.description,
+      redirect_url: success_payments_url(payment_id: payment.id),
+      webhook_url: webhook_payments_url,
+      metadata: { payment_id: payment.id, participant_id: @participant.id }
+    )
+  end
+
+  def retryable_mollie_status?(status)
+    %w[open pending authorized].include?(status)
   end
 end

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -115,6 +115,23 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     Mollie::Payment.define_singleton_method(:get, &original)
   end
 
+  test "create redirects to success when mollie already marks the payment as paid" do
+    payment = payments(:open_payment)
+    mollie_stub = OpenStruct.new(id: payment.mollie_payment_id, status: "paid", checkout_url: "https://example.test/paid-checkout")
+
+    original = Mollie::Payment.method(:get)
+    Mollie::Payment.define_singleton_method(:get) { |_id| mollie_stub }
+
+    assert_no_difference("Payment.count") do
+      post participant_payment_path(payment.participant)
+    end
+
+    assert_equal "paid", payment.reload.status
+    assert_redirected_to success_payments_path
+  ensure
+    Mollie::Payment.define_singleton_method(:get, &original)
+  end
+
   test "create starts a new payment attempt when previous mollie checkout is unavailable" do
     payment = payments(:open_payment)
     stale_mollie = OpenStruct.new(id: payment.mollie_payment_id, status: "failed", checkout_url: nil)

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -67,6 +67,23 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to success_payments_path
   end
 
+  test "create starts a single payment when no in-progress payment exists" do
+    participant = participants(:three)
+    mollie_stub = OpenStruct.new(id: "tr_new_attempt_123", checkout_url: "https://example.test/new-checkout")
+
+    original = Mollie::Payment.method(:create)
+    Mollie::Payment.define_singleton_method(:create) { |_params| mollie_stub }
+
+    assert_difference("Payment.count", 1) do
+      post participant_payment_path(participant)
+    end
+
+    assert_redirected_to "https://example.test/new-checkout"
+    assert_equal "tr_new_attempt_123", participant.payments.order(created_at: :desc).first.mollie_payment_id
+  ensure
+    Mollie::Payment.define_singleton_method(:create, original)
+  end
+
   test "create keeps confirmed payment view state when mollie creation fails" do
     participant = participants(:three)
 

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -84,7 +84,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
 
   test "create reuses the latest in-progress payment" do
     payment = payments(:open_payment)
-    mollie_stub = OpenStruct.new(id: payment.mollie_payment_id, checkout_url: "https://example.test/mollie-checkout")
+    mollie_stub = OpenStruct.new(id: payment.mollie_payment_id, status: "open", checkout_url: "https://example.test/mollie-checkout")
 
     original = Mollie::Payment.method(:get)
     Mollie::Payment.define_singleton_method(:get) { |_id| mollie_stub }
@@ -96,6 +96,27 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "https://example.test/mollie-checkout"
   ensure
     Mollie::Payment.define_singleton_method(:get, original)
+  end
+
+  test "create starts a new payment attempt when previous mollie checkout is unavailable" do
+    payment = payments(:open_payment)
+    stale_mollie = OpenStruct.new(id: payment.mollie_payment_id, status: "failed", checkout_url: nil)
+    new_mollie = OpenStruct.new(id: "tr_new_attempt_123", checkout_url: "https://example.test/new-checkout")
+
+    original_get = Mollie::Payment.method(:get)
+    original_create = Mollie::Payment.method(:create)
+    Mollie::Payment.define_singleton_method(:get) { |_id| stale_mollie }
+    Mollie::Payment.define_singleton_method(:create) { |_params| new_mollie }
+
+    assert_difference("Payment.count", 1) do
+      post participant_payment_path(payment.participant)
+    end
+
+    assert_redirected_to "https://example.test/new-checkout"
+    assert_equal "tr_new_attempt_123", payment.participant.payments.order(created_at: :desc).first.mollie_payment_id
+  ensure
+    Mollie::Payment.define_singleton_method(:get, original_get)
+    Mollie::Payment.define_singleton_method(:create, original_create)
   end
 
   # success

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -81,7 +81,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "https://example.test/new-checkout"
     assert_equal "tr_new_attempt_123", participant.payments.order(created_at: :desc).first.mollie_payment_id
   ensure
-    Mollie::Payment.define_singleton_method(:create, original)
+    Mollie::Payment.define_singleton_method(:create, &original)
   end
 
   test "create keeps confirmed payment view state when mollie creation fails" do
@@ -96,7 +96,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Payment could not be started: boom", response.body
     assert_no_match "Please confirm your email address", response.body
   ensure
-    Mollie::Payment.define_singleton_method(:create, original)
+    Mollie::Payment.define_singleton_method(:create, &original)
   end
 
   test "create reuses the latest in-progress payment" do
@@ -112,7 +112,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to "https://example.test/mollie-checkout"
   ensure
-    Mollie::Payment.define_singleton_method(:get, original)
+    Mollie::Payment.define_singleton_method(:get, &original)
   end
 
   test "create starts a new payment attempt when previous mollie checkout is unavailable" do
@@ -132,8 +132,8 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to "https://example.test/new-checkout"
     assert_equal "tr_new_attempt_123", payment.participant.payments.order(created_at: :desc).first.mollie_payment_id
   ensure
-    Mollie::Payment.define_singleton_method(:get, original_get)
-    Mollie::Payment.define_singleton_method(:create, original_create)
+    Mollie::Payment.define_singleton_method(:get, &original_get)
+    Mollie::Payment.define_singleton_method(:create, &original_create)
   end
 
   # success
@@ -162,7 +162,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "Payment Pending", response.body
   ensure
-    Mollie::Payment.define_singleton_method(:get, original)
+    Mollie::Payment.define_singleton_method(:get, &original)
   end
 
   # webhook
@@ -174,7 +174,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
   ensure
-    Mollie::Payment.define_singleton_method(:get, original)
+    Mollie::Payment.define_singleton_method(:get, &original)
   end
 
   test "webhook updates payment status" do
@@ -189,7 +189,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal "paid", payment.reload.status
   ensure
-    Mollie::Payment.define_singleton_method(:get, original)
+    Mollie::Payment.define_singleton_method(:get, &original)
   end
 
   test "webhook is not blocked by the modern browser guard" do
@@ -212,6 +212,6 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal "paid", payment.reload.status
   ensure
-    Mollie::Payment.define_singleton_method(:get, original)
+    Mollie::Payment.define_singleton_method(:get, &original)
   end
 end

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -72,7 +72,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     mollie_stub = OpenStruct.new(id: "tr_new_attempt_123", checkout_url: "https://example.test/new-checkout")
 
     original = Mollie::Payment.method(:create)
-    Mollie::Payment.define_singleton_method(:create) { |_params| mollie_stub }
+    Mollie::Payment.define_singleton_method(:create) { |**_params| mollie_stub }
 
     assert_difference("Payment.count", 1) do
       post participant_payment_path(participant)
@@ -88,7 +88,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     participant = participants(:three)
 
     original = Mollie::Payment.method(:create)
-    Mollie::Payment.define_singleton_method(:create) { |_params| raise Mollie::Exception, "boom" }
+    Mollie::Payment.define_singleton_method(:create) { |**_params| raise Mollie::Exception, "boom" }
 
     post participant_payment_path(participant)
 
@@ -140,7 +140,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     original_get = Mollie::Payment.method(:get)
     original_create = Mollie::Payment.method(:create)
     Mollie::Payment.define_singleton_method(:get) { |_id| stale_mollie }
-    Mollie::Payment.define_singleton_method(:create) { |_params| new_mollie }
+    Mollie::Payment.define_singleton_method(:create) { |**_params| new_mollie }
 
     assert_difference("Payment.count", 1) do
       post participant_payment_path(payment.participant)

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -117,7 +117,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
 
   test "create redirects to success when mollie already marks the payment as paid" do
     payment = payments(:open_payment)
-    mollie_stub = OpenStruct.new(id: payment.mollie_payment_id, status: "paid", checkout_url: "https://example.test/paid-checkout")
+    mollie_stub = OpenStruct.new(id: payment.mollie_payment_id, status: "paid")
 
     original = Mollie::Payment.method(:get)
     Mollie::Payment.define_singleton_method(:get) { |_id| mollie_stub }

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -130,6 +130,7 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to "https://example.test/new-checkout"
+    assert_equal "failed", payment.reload.status
     assert_equal "tr_new_attempt_123", payment.participant.payments.order(created_at: :desc).first.mollie_payment_id
   ensure
     Mollie::Payment.define_singleton_method(:get, &original_get)


### PR DESCRIPTION
If an endstate was reached, the payment could not be reused